### PR TITLE
Fix the name of habits container

### DIFF
--- a/backend/api-gateway/.gitignore
+++ b/backend/api-gateway/.gitignore
@@ -4,5 +4,6 @@ node_modules
 /.svelte-kit
 /package
 .env
+variables.env
 .env.*
 !.env.example

--- a/backend/habits/.gitignore
+++ b/backend/habits/.gitignore
@@ -4,5 +4,6 @@ node_modules
 /.svelte-kit
 /package
 .env
+variables.env
 .env.*
 !.env.example

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.8'
 services:
   habits:
-    container_name: ms-habits
+    container_name: mshabits
     build: ./backend/habits
     volumes:
       - ./backend/habits/code:/usr/src/app


### PR DESCRIPTION
The branches introduces a fix to the name of the container for habits microservice in the `docker-compose` file