### PR TITLE
Hotfix - Fix the character length to 8

### DIFF
--- a/frontend/src/routes/profile/+page.server.js
+++ b/frontend/src/routes/profile/+page.server.js
@@ -115,8 +115,8 @@ async function validateChangingPasswordData(currentPassword, newPassword, confir
     validationIssues.push({ "input": "confirm-new-password", "message": "" });
   }
 
-  if (newPassword.length < 12) {
-    validationIssues.push({ "input": "new-password", "message": "The new password should be at least 12 characters long" });
+  if (newPassword.length < 8) {
+    validationIssues.push({ "input": "new-password", "message": "The new password should be at least 8 characters long" });
     validationIssues.push({ "input": "confirm-new-password", "message": "" });
   }
 


### PR DESCRIPTION
When changing password instead of 8 characters in the profile page it requires 12. The hotfix changes this